### PR TITLE
Fix for bug #65, copy gene tag in to GFF Name attribute

### DIFF
--- a/bin/snippy
+++ b/bin/snippy
@@ -142,6 +142,10 @@ while (my $seq = $in->next_seq) {
       my($id) = $f->get_tag_values('locus_tag');
       $f->add_tag_value('ID', $id);
     }
+    if ($f->has_tag('gene')) {
+      my($gene) = $f->get_tag_values('gene');
+      $f->add_tag_value('Name', $gene);
+    }
     $gff->write_feature($f);
     $nfeat++;
   }


### PR DESCRIPTION
Small fix to copy the "gene" tag from CDS features in to the GFF Name attribute. This means that the human-readable gene names are included in the final VCF.
